### PR TITLE
Fix consumer Vite smoke build setup and add type annotations (plus pagination test wait)

### DIFF
--- a/packages/consumer-smoke-vite/src/App.tsx
+++ b/packages/consumer-smoke-vite/src/App.tsx
@@ -1,5 +1,5 @@
 import { RowaKitTable, col } from '@rowakit/table';
-import type { Fetcher, BulkActionDef, Exporter } from '@rowakit/table';
+import type { Fetcher, BulkActionDef, Exporter, FetcherQuery } from '@rowakit/table';
 
 /**
  * Consumer Smoke Test — Type Safety Validation
@@ -39,7 +39,7 @@ const generateUsers = (count: number): User[] => {
 const allUsers = generateUsers(1000);
 
 // Fetcher with proper typing (no `any`)
-const fetchUsers: Fetcher<User> = async (query) => {
+const fetchUsers: Fetcher<User> = async (query: FetcherQuery) => {
   await new Promise((resolve) => setTimeout(resolve, 300)); // Simulate network
 
   let filtered = [...allUsers];
@@ -109,7 +109,7 @@ const bulkActions: BulkActionDef[] = [
   {
     id: 'activate',
     label: 'Activate selected',
-    onClick: (keys) => {
+    onClick: (keys: Array<string | number>) => {
       console.log('Activating users:', keys);
       alert(`Would activate ${keys.length} users`);
     },
@@ -121,7 +121,7 @@ const bulkActions: BulkActionDef[] = [
       title: 'Confirm deletion',
       description: 'Are you sure you want to delete these users?',
     },
-    onClick: (keys) => {
+    onClick: (keys: Array<string | number>) => {
       console.log('Deleting users:', keys);
       alert(`Would delete ${keys.length} users`);
     },
@@ -129,7 +129,7 @@ const bulkActions: BulkActionDef[] = [
 ];
 
 // Exporter with proper typing (no `any`)
-const exporter: Exporter = async (query) => {
+const exporter: Exporter = async (query: FetcherQuery) => {
   await new Promise((resolve) => setTimeout(resolve, 500));
   
   console.log('Export requested with query:', query);
@@ -184,7 +184,7 @@ function App() {
           col.number('salary', {
             header: 'Salary',
             sortable: true,
-            format: (val) => new Intl.NumberFormat('en-US', {
+            format: (val: number) => new Intl.NumberFormat('en-US', {
               style: 'currency',
               currency: 'USD',
             }).format(val),
@@ -201,18 +201,18 @@ function App() {
             { 
               id: 'edit', 
               label: 'Edit',
-              onClick: (row) => alert(`Edit user: ${row.name}`),
+              onClick: (row: User) => alert(`Edit user: ${row.name}`),
             },
             { 
               id: 'view', 
               label: 'View',
-              onClick: (row) => alert(`View user: ${row.name}`),
+              onClick: (row: User) => alert(`View user: ${row.name}`),
             },
             { 
               id: 'delete', 
               label: 'Delete', 
               confirm: true,
-              onClick: (row) => console.log('Delete user:', row.id),
+              onClick: (row: User) => console.log('Delete user:', row.id),
             },
           ]),
         ]}

--- a/packages/table/src/__tests__/consumer-smoke.vite.test.ts
+++ b/packages/table/src/__tests__/consumer-smoke.vite.test.ts
@@ -28,14 +28,14 @@ const VITE_CONSUMER_DIR = resolve(__dirname, '../../../../packages/consumer-smok
 
 beforeAll(() => {
   // Build consumer-smoke-vite before running tests
-  try {
-    execSync('pnpm --filter @rowakit/consumer-smoke-vite build', {
-      cwd: resolve(__dirname, '../../../../'),
-      stdio: 'pipe',
-    });
-  } catch (error) {
-    console.warn('Failed to build consumer-smoke-vite in test setup:', error);
-  }
+  execSync('pnpm --filter @rowakit/table build', {
+    cwd: resolve(__dirname, '../../../../'),
+    stdio: 'inherit',
+  });
+  execSync('pnpm --filter @rowakit/consumer-smoke-vite build', {
+    cwd: resolve(__dirname, '../../../../'),
+    stdio: 'inherit',
+  });
 });
 
 describe('Consumer Smoke Test: Vite', () => {

--- a/packages/table/src/components/SmartTable.pagination.test.tsx
+++ b/packages/table/src/components/SmartTable.pagination.test.tsx
@@ -112,7 +112,7 @@ describe('SmartTable - Pagination (A-06)', () => {
       });
 
       // Navigate to page 2
-      const nextButton = screen.getByRole('button', { name: 'Next page' });
+      const nextButton = await screen.findByRole('button', { name: 'Next page' });
       await user.click(nextButton);
 
       await waitFor(() => {


### PR DESCRIPTION
### Motivation
- Ensure the Vite consumer smoke test reliably verifies consumer builds by producing table package artifacts before building the consumer; previous setup allowed a missing `dist` and caused ENOENT errors.  
- Satisfy strict TypeScript checks in the consumer example app by adding explicit type annotations to avoid `tsc` failures during the smoke build.  
- Make a pagination test more robust by waiting for the Next button to appear before interacting with it.

### Description
- In `packages/table/src/__tests__/consumer-smoke.vite.test.ts`, run `pnpm --filter @rowakit/table build` before building the `@rowakit/consumer-smoke-vite` app and use `stdio: 'inherit'` so build failures surface in CI output.  
- In `packages/consumer-smoke-vite/src/App.tsx`, add explicit type imports and annotations for `FetcherQuery`, fetcher parameter types, bulk action `onClick` parameter types, exporter parameter type, action handlers, and number formatter callback to satisfy strict TypeScript.  
- In `packages/table/src/components/SmartTable.pagination.test.tsx`, replace `screen.getByRole('button', { name: 'Next page' })` with `await screen.findByRole('button', { name: 'Next page' })` to wait for the button before clicking.

### Testing
- Ran `pnpm -C packages/table test`, which executed the test suite and completed with all tests passing; Vitest reported 23 test files and 326 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b2e4d914832a9050bdb741fff4c8)